### PR TITLE
Update ShowDefaultCloseButtonConverter.cs

### DIFF
--- a/Dragablz/Converters/ShowDefaultCloseButtonConverter.cs
+++ b/Dragablz/Converters/ShowDefaultCloseButtonConverter.cs
@@ -19,7 +19,9 @@ namespace Dragablz.Converters
         /// <returns></returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            return ((bool) values[0] && (int)values[2] >= (int)values[1]) ? Visibility.Visible : Visibility.Collapsed;
+            return ((values[0] == DependencyProperty.UnsetValue ? false : (bool)values[0]) && 
+                    (values[2] == DependencyProperty.UnsetValue ? 0 : (int)values[2]) >= 
+                    (values[1] == DependencyProperty.UnsetValue ? 0 : (int)values[1])) ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)


### PR DESCRIPTION
Handle situations where Convert receives UnsetValue (nulls) when binding.